### PR TITLE
Added form token helper

### DIFF
--- a/src/Compilers/HandlebarsCompiler.php
+++ b/src/Compilers/HandlebarsCompiler.php
@@ -116,7 +116,7 @@ class HandlebarsCompiler extends Compiler implements CompilerInterface {
         if($this->languageHelpers)
         {
             if ( ! $raw) {
-                $helpers = array_merge($this->getLanguageHelpers(), $options['helpers']);
+                $helpers = array_merge($this->getHelpers(), $options['helpers']);
             } elseif ($this->translateRawOutput) {
                 $helpers = $this->getLanguageHelpers();
             } else {
@@ -149,6 +149,31 @@ class HandlebarsCompiler extends Compiler implements CompilerInterface {
     }
 
     /**
+     *
+     * Get all helpers included that come included in this package
+     *
+     * @return array
+     */
+    protected function getHelpers()
+    {
+        return array_merge($this->getFormHelpers(), $this->getLanguageHelpers());
+    }
+
+    /**
+     * Get form helper functions.
+     *
+     * @return array
+     */
+    protected function getFormHelpers()
+    {
+        return [
+            'form_token' => function() {
+                return '<input type="hidden" name="_token" value="' . csrf_token() . '" />';
+            }
+        ];
+    }
+
+    /**
      * Get language helper functions.
      *
      * @return array
@@ -164,5 +189,4 @@ class HandlebarsCompiler extends Compiler implements CompilerInterface {
             }
         ];
     }
-
 }


### PR DESCRIPTION
While trying to fix the issue with cached partials I had another issue.

Not so much a problem with this package, but something additional I could use to simplify adding a csrf token to form which is needed by default for laravel 5 when working with forms.

A lot of people like to use form helpers in blade like Form::open and Form::token but been able to also utilize them with handlebars as {{{form_token }}} I think is very handy and clean to write.

I added the code for this and also abstracted it in the compiler so it easier to add commonly used helpers to this package.
