### PR TITLE
Better detect toArray() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+composer.phar
+composer.lock
+.DS_Store

--- a/src/Engines/HandlebarsEngine.php
+++ b/src/Engines/HandlebarsEngine.php
@@ -63,7 +63,7 @@ class HandlebarsEngine extends CompilerEngine implements EngineInterface {
 
     protected function convertObjectToArray($item)
     {
-        if (is_object($item) && method_exists($item, 'toArray')) {
+        if (is_object($item) && is_callable([$item, 'toArray'])) {
             $item = $item->toArray();
         }
 


### PR DESCRIPTION
Using `is_callable` in place of the `is_method` will better help determine if the object has the `toArray` method.
