### PR TITLE
LightnCandy v0.95, test for @partial-block nesting added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/view": "5.*",
-        "zordius/lightncandy": "0.94"
+        "zordius/lightncandy": "0.95"
     },
     "require-dev": {
         "orchestra/testbench": "~3.2"

--- a/tests/expected/handlebars.html
+++ b/tests/expected/handlebars.html
@@ -44,3 +44,19 @@
     </div>
 </div>
 
+
+<ul>
+        <li>
+            One
+        </li>
+
+        <li>
+            Two
+        </li>
+
+        <li>
+            Three
+        </li>
+
+</ul>
+

--- a/tests/views/handlebars.hbs
+++ b/tests/views/handlebars.hbs
@@ -49,3 +49,15 @@
 {{#> partialBlock label="<textarea> Element" name="textarea"}}
     <textarea id="textarea">Test</textarea>
 {{/partialBlock}}
+
+{{#> outerPartialBlock}}
+    {{#> innerPartialBlock}}
+        One
+    {{/innerPartialBlock}}
+    {{#> innerPartialBlock}}
+        Two
+    {{/innerPartialBlock}}
+    {{#> innerPartialBlock}}
+        Three
+    {{/innerPartialBlock}}
+{{/outerPartialBlock}}

--- a/tests/views/innerPartialBlock.hbs
+++ b/tests/views/innerPartialBlock.hbs
@@ -1,0 +1,3 @@
+<li>
+    {{> @partial-block }}
+</li>

--- a/tests/views/outerPartialBlock.hbs
+++ b/tests/views/outerPartialBlock.hbs
@@ -1,0 +1,3 @@
+<ul>
+    {{> @partial-block }}
+</ul>


### PR DESCRIPTION
Updated to [LightnCandy v0.95](https://github.com/zordius/lightncandy/releases/tag/v0.95)
- align with handlebars.js 4.0.5
- fix {{> (lookup foo bar)}} issue (allow builtin helpers in subexpression)
- fix comment inside partial block issue
- fix @partial-block id generation issue

I also added a PHPUnit test for nesting `@partial-block`!
