### PR TITLE
ensure that toArray method actually exists on object when calling convertObjectToArray

### DIFF
--- a/src/Engines/HandlebarsEngine.php
+++ b/src/Engines/HandlebarsEngine.php
@@ -63,7 +63,7 @@ class HandlebarsEngine extends CompilerEngine implements EngineInterface
 
     protected function convertObjectToArray($item)
     {
-        if (is_object($item) && is_callable([$item, 'toArray'])) {
+        if (is_object($item) && method_exists($item, 'toArray') && is_callable([$item, 'toArray'])) {
             $item = $item->toArray();
         }
 


### PR DESCRIPTION
When using a handlebars / mustache template as a view for a Laravel Mailable which is queued, the exception `call_user_func_array() expects parameter 1 to be a valid callback, class 'Swift_Message' does not have a method 'toArray' in /var/www/vendor/laravel/framework/src/Illuminate/Mail/Message.php:296` is thrown.

This is because Laravel injects the `message` - an instance of `Illuminate\Mail\Message` as a variable into the view.  The `is_callable` check in `convertObjectToArray` returns true because the `message` object has a magic `__call` function which passes the call on to the `\Swift_Message` object, and this object has no `toArray` call.

This PR changes `convertObjectToArray` to check if the method exists and the method is callable / public.
