### PR TITLE
Support laravel 5.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/view": "5.*",
+        "illuminate/view": "^5.5",
         "zordius/lightncandy": "1.1.*"
     },
     "require-dev": {

--- a/src/Engines/HandlebarsEngine.php
+++ b/src/Engines/HandlebarsEngine.php
@@ -1,9 +1,9 @@
 <?php namespace ProAI\Handlebars\Engines;
 
-use Illuminate\View\Engines\EngineInterface;
+use Illuminate\Contracts\View\Engine;
 use Illuminate\View\Engines\CompilerEngine;
 
-class HandlebarsEngine extends CompilerEngine implements EngineInterface
+class HandlebarsEngine extends CompilerEngine implements Engine
 {
 
     /**


### PR DESCRIPTION
Taylor made yet another breaking change in a minor version...

Ref. https://github.com/laravel/framework/pull/20464

What is the best way to tackle this down?