### PR TITLE
Upgrade light'n'candy to 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/view": "^5.5",
-        "zordius/lightncandy": "1.1.*"
+        "zordius/lightncandy": "1.2.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.2",


### PR DESCRIPTION
https://github.com/zordius/lightncandy/releases/tag/v1.2.0

It's mostly fixes regarding mustache (which I don't use) and it aligns with handlebars 4.0.10 (which I use).

Signed-off-by: Yoan Blanc <yoan@dosimple.ch>