### PR TITLE
Update HandlebarsServiceProvider.php

### DIFF
--- a/src/HandlebarsServiceProvider.php
+++ b/src/HandlebarsServiceProvider.php
@@ -45,31 +45,9 @@ class HandlebarsServiceProvider extends ServiceProvider
     protected function registerEngineResolverExtensions()
     {
         $this->app->extend('view.engine.resolver', function ($resolver, $app) {
-            $this->registerBladeEngine($resolver);
-
             $this->registerHandlebarsEngine($resolver);
 
             return $resolver;
-        });
-    }
-
-    /**
-     * Register the Blade engine implementation.
-     *
-     * @param  \Illuminate\View\Engines\EngineResolver $resolver
-     * @return void
-     */
-    public function registerBladeEngine($resolver)
-    {
-        $app = $this->app;
-
-        // The Compiler engine requires an instance of the CompilerInterface, which in
-        // this case will be the Blade compiler, so we'll first create the compiler
-        // instance to pass into the engine so it can compile the views properly.
-        $app->singleton('blade.compiler', function ($app) {
-            $cache = $app['config']['view.compiled'];
-
-            return new BladeCompiler($app['files'], $cache);
         });
     }
 


### PR DESCRIPTION
Do not reregister BladeCompiler in Service Provider. It will already have been registered by the framework. Re-registering will cause Blade::withoutDoubleEncoding(); that has been called in AppServiceProvider to be effectively ignored, as the BladeComiler's echoFormat parameter will have been reset.